### PR TITLE
Code quality fix - Constructors should only call non-overridable methods

### DIFF
--- a/src/main/java/net/openhft/chronicle/algo/bitset/ReusableBitSet.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/ReusableBitSet.java
@@ -30,7 +30,7 @@ public class ReusableBitSet implements BitSet {
         reuse(frame, access, handle, offset);
     }
 
-    public <T> ReusableBitSet reuse(
+    public final <T> ReusableBitSet reuse(
             BitSetFrame frame, Access<T> access, T handle, long offset) {
         this.frame = frame;
         this.access = access;

--- a/src/main/java/net/openhft/chronicle/algo/hashing/CityHash_1_1.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/CityHash_1_1.java
@@ -367,7 +367,7 @@ class CityHash_1_1 {
         }
 
         @Override
-        protected long finalize(long hash) {
+        protected final long finalize(long hash) {
             return hashLen16(hash - seed0, seed1);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S1699 - Constructors should only call non-overridable methods

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Faisal