### PR TITLE
Update java-parent-pom version.

### DIFF
--- a/measures/pom.xml
+++ b/measures/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-bom</artifactId>
-                <version>1.17-SNAPSHOT</version>
+                <version>1.18-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.1.17</version>
+        <version>1.1.18</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Please review: it's not clear to me if the `chronicle-bom` version should be bumpted to `1.18-SNAPSHOT` here...