### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/measures/pom.xml
+++ b/measures/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/AddressWrapper.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/AddressWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/AddressWrappers.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/AddressWrappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/AvalancheScore.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/AvalancheScore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/CheckMain.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/CheckMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/MainBytes.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/MainBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/MaskHashScore.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/MaskHashScore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/measures/src/main/java/net/openhft/chronicle/algorithms/measures/OrtogonalBitsScore.java
+++ b/measures/src/main/java/net/openhft/chronicle/algorithms/measures/OrtogonalBitsScore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algorithms.measures;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <description>Chronicle-Algorithms</description>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <jacoco.line.coverage>0.56</jacoco.line.coverage>
         <jacoco.branch.coverage>0.35</jacoco.branch.coverage>
     </properties>

--- a/src/main/java/net/openhft/chronicle/algo/MemoryUnit.java
+++ b/src/main/java/net/openhft/chronicle/algo/MemoryUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 
 /*

--- a/src/main/java/net/openhft/chronicle/algo/bitset/BitSet.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/BitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bitset/BitSetAlgorithm.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/BitSetAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bitset/BitSetFrame.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/BitSetFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bitset/ConcurrentFlatBitSetFrame.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/ConcurrentFlatBitSetFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bitset/FlatBitSetAlgorithm.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/FlatBitSetAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bitset/ReusableBitSet.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/ReusableBitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bitset/SingleThreadedFlatBitSetFrame.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/SingleThreadedFlatBitSetFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/Access.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/AccessCommon.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/AccessCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/Accessor.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/Accessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/ArrayAccessors.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/ArrayAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/ByteBufferAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/ByteBufferAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/ByteBufferAccessor.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/ByteBufferAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/BytesAccesses.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/BytesAccesses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/BytesAccessors.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/BytesAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/CharSequenceAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/CharSequenceAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/CharSequenceAccessor.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/CharSequenceAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/HotSpotStringAccessor.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/HotSpotStringAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/NativeAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/NativeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/RandomDataInputAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/RandomDataInputAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/RandomDataOutputAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/RandomDataOutputAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/ReadAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/ReadAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/WriteAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/WriteAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/bytes/ZeroAccess.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/ZeroAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/main/java/net/openhft/chronicle/algo/hashing/CityHash_1_1.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/CityHash_1_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/main/java/net/openhft/chronicle/algo/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/LongHashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/main/java/net/openhft/chronicle/algo/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/MurmurHash_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/main/java/net/openhft/chronicle/algo/hashing/Primitives.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/Primitives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/main/java/net/openhft/chronicle/algo/hashing/XxHash_r39.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/XxHash_r39.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/main/java/net/openhft/chronicle/algo/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/algo/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/AcquisitionStrategies.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/AcquisitionStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/AcquisitionStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/AcquisitionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/LockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/LockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/LockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/LockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteLockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteLockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateLockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateLockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateWithWaitsLockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateWithWaitsLockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateWithWaitsLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteUpdateWithWaitsLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteWithWaitsLockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteWithWaitsLockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteWithWaitsLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/ReadWriteWithWaitsLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/TryAcquireOperation.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/TryAcquireOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/TryAcquireOperations.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/TryAcquireOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/VanillaReadWriteUpdateWithWaitsLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/VanillaReadWriteUpdateWithWaitsLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/VanillaReadWriteWithWaitsLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/VanillaReadWriteWithWaitsLockingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/bitset/BitSetFrameTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bitset/BitSetFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/test/java/net/openhft/chronicle/algo/bitset/BitSetTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bitset/BitSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/test/java/net/openhft/chronicle/algo/bitset/ConcurrentFlatBitSetFrameTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bitset/ConcurrentFlatBitSetFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/test/java/net/openhft/chronicle/algo/bitset/DirectBitSetTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bitset/DirectBitSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/test/java/net/openhft/chronicle/algo/bitset/FlatBitSetAlgorithmTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bitset/FlatBitSetAlgorithmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bitset;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/AccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/AccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/ByteBufferAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/ByteBufferAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/CharSequenceAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/RandomDataInputAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/RandomDataInputAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/RandomDataOutputAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/RandomDataOutputAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/WriteAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/WriteAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/ZeroAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/ZeroAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.bytes;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/City64MoreTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/City64MoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/City64_1_1_Test.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/City64_1_1_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/HashSearcherMain.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/HashSearcherMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/HashTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/HashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/HashTesterMain.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/HashTesterMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/HashTesterRunner.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/HashTesterRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/LongHashFunctionTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/LongHashFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/MurmurHash3MoreTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/MurmurHash3MoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/MurmurHash3Test.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/MurmurHash3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/RandomOptimiser.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/RandomOptimiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/hashing/XxHash_r39_Test.java
+++ b/src/test/java/net/openhft/chronicle/algo/hashing/XxHash_r39_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.hashing;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockStateTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockingStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/AcquisitionStrategiesTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/AcquisitionStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/LockingStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/LockingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/TryAcquireOperationsTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/TryAcquireOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/VanillaReadWriteUpdateWithWaitsLockingStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/VanillaReadWriteUpdateWithWaitsLockingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/algo/locks/VanillaReadWriteWithWaitsLockingStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/locks/VanillaReadWriteWithWaitsLockingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.algo.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/ChronicleStampedLockTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/ChronicleStampedLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)