### PR TITLE
docs: close the space in "i. e." and "e. g."

### DIFF
--- a/src/main/java/net/openhft/chronicle/algo/MemoryUnit.java
+++ b/src/main/java/net/openhft/chronicle/algo/MemoryUnit.java
@@ -121,7 +121,7 @@ public enum MemoryUnit {
     },
 
     /**
-     * Memory unit representing one byte, i. e. 8 bits.
+     * Memory unit representing one byte, i.e. 8 bits.
      */
     BYTES {
         @Override
@@ -211,7 +211,7 @@ public enum MemoryUnit {
     },
 
     /**
-     * Memory unit representing 8 bytes, i. e. 64-bit word,
+     * Memory unit representing 8 bytes, i.e. 64-bit word,
      * the width of Java's primitive {@code long} type.
      */
     LONGS {
@@ -302,7 +302,7 @@ public enum MemoryUnit {
     },
 
     /**
-     * Memory unit representing 64 bytes, i. e. the most common CPU cache line size.
+     * Memory unit representing 64 bytes, i.e. the most common CPU cache line size.
      */
     CACHE_LINES {
         @Override
@@ -482,7 +482,7 @@ public enum MemoryUnit {
     },
 
     /**
-     * Memory unit representing 4096 bytes, i. e. the most common native memory page size.
+     * Memory unit representing 4096 bytes, i.e. the most common native memory page size.
      */
     PAGES {
         @Override
@@ -835,7 +835,7 @@ public enum MemoryUnit {
     /**
      * Aligns the given memory amount in the given unit to this unit. For example, aligning
      * {@code 1000} bytes to kilobytes results in {@code 1024}. Negative values are aligned towards
-     * negative infinity: e. g. aligning {@code -5} longs to cache lines results in {@code -8}.
+     * negative infinity: e.g. aligning {@code -5} longs to cache lines results in {@code -8}.
      *
      * @param amountToAlign the memory amount in the given {@code unit}
      * @param unit          the unit of the {@code amountToAlign} argument

--- a/src/main/java/net/openhft/chronicle/algo/bitset/ConcurrentFlatBitSetFrame.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/ConcurrentFlatBitSetFrame.java
@@ -714,7 +714,7 @@ public final class ConcurrentFlatBitSetFrame implements BitSetFrame {
                     if (x != 0) {
                         int trailingOnes = numberOfTrailingZeros(x);
                         bitIndex += trailingOnes;
-                        // i. e. bitIndex + numberOfBits crosses 64 boundary
+                        // i.e. bitIndex + numberOfBits crosses 64 boundary
                         if ((bitIndex & 63) > n64Complement)
                             break continueLongLoop;
                         // (2)
@@ -747,7 +747,7 @@ public final class ConcurrentFlatBitSetFrame implements BitSetFrame {
                     if (x != 0) {
                         int trailingOnes = numberOfTrailingZeros(x);
                         bitIndex += trailingOnes;
-                        // i. e. bitIndex + numberOfBits crosses 64 boundary
+                        // i.e. bitIndex + numberOfBits crosses 64 boundary
                         if ((bitIndex & 63) > n64Complement)
                             break continueLongLoop;
                         // already shifted with one-filling at least once
@@ -812,7 +812,7 @@ public final class ConcurrentFlatBitSetFrame implements BitSetFrame {
                     if (l != 0) {
                         int trailingZeros = numberOfTrailingZeros(l);
                         bitIndex += trailingZeros;
-                        // i. e. bitIndex + numberOfBits crosses 64 boundary
+                        // i.e. bitIndex + numberOfBits crosses 64 boundary
                         if ((bitIndex & 63) > n64Complement)
                             break continueLongLoop;
                         l >>>= trailingZeros;
@@ -841,7 +841,7 @@ public final class ConcurrentFlatBitSetFrame implements BitSetFrame {
                     if (l != 0) {
                         int trailingZeros = numberOfTrailingZeros(l);
                         bitIndex += trailingZeros;
-                        // i. e. bitIndex + numberOfBits crosses 64 boundary
+                        // i.e. bitIndex + numberOfBits crosses 64 boundary
                         if ((bitIndex & 63) > n64Complement)
                             break continueLongLoop;
                         l >>>= trailingZeros;
@@ -959,7 +959,7 @@ public final class ConcurrentFlatBitSetFrame implements BitSetFrame {
      * WARNING! This implementation doesn't strictly follow the contract
      * from {@code DirectBitSet} interface. For the sake of atomicity this
      * implementation couldn't find and flip the range crossing native word
-     * boundary, e. g. bits from 55 to 75 (boundary is 64).
+     * boundary, e.g. bits from 55 to 75 (boundary is 64).
      *
      * @throws IllegalArgumentException if {@code numberOfBits}
      *                                  is out of range {@code 0 < numberOfBits && numberOfBits <= 64}

--- a/src/main/java/net/openhft/chronicle/algo/bitset/SingleThreadedFlatBitSetFrame.java
+++ b/src/main/java/net/openhft/chronicle/algo/bitset/SingleThreadedFlatBitSetFrame.java
@@ -25,7 +25,7 @@ public final class SingleThreadedFlatBitSetFrame implements BitSetFrame {
      * Creates a new {@code SingleThreadedFlatBitSetFrame} of the given logical size.
      *
      * @param logicalSize the logical bit set size, should be {@code long}-aligned
-     *                    (i. e. a multiple of 8)
+     *                    (i.e. a multiple of 8)
      * @throws IllegalArgumentException is the given logicalSize is not a multiple of 8
      *                                  or non-positive
      */
@@ -37,7 +37,7 @@ public final class SingleThreadedFlatBitSetFrame implements BitSetFrame {
         longLength = BITS.toLongs(logicalSize);
         if (LONGS.toBits(longLength) != logicalSize) {
             throw new IllegalArgumentException(
-                    "logical size should be long-aligned (i. e. a multiple of 8), " +
+                    "logical size should be long-aligned (i.e. a multiple of 8), " +
                             logicalSize + " given");
         }
     }

--- a/src/main/java/net/openhft/chronicle/algo/bytes/Accessor.java
+++ b/src/main/java/net/openhft/chronicle/algo/bytes/Accessor.java
@@ -152,7 +152,7 @@ public interface Accessor<S, T, A extends AccessCommon<T>> {
     /**
      * Convert size (length) in the source domain to size in bytes.
      * <p>
-     * The default implementation returns the given {@code size} back, i. e. assuming
+     * The default implementation returns the given {@code size} back, i.e. assuming
      * byte-indexed source.
      *
      * @param size size (length) in the source type domain

--- a/src/main/java/net/openhft/chronicle/algo/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/LongHashFunction.java
@@ -353,7 +353,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code char} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in chars (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in chars (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
@@ -377,7 +377,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the string which bytes to hash
      * @param off   index of the first {@code char} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in chars (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in chars (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return the hash code of the given {@code String}'s bytes
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
@@ -401,7 +401,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the string builder which bytes to hash
      * @param off   index of the first {@code char} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in chars (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in chars (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return the hash code of the given {@code String}'s bytes
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
@@ -433,7 +433,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code short} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in shorts (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in shorts (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
@@ -457,7 +457,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code int} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in ints (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in ints (i.e. the length of the bytes
      *              sequence to hash is {@code len * 4L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
@@ -481,7 +481,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code long} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in longs (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in longs (i.e. the length of the bytes
      *              sequence to hash is {@code len * 8L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}


### PR DESCRIPTION
## Summary
- Replaces `i. e.` with `i.e.` and `e. g.` with `e.g.` in javadoc / AsciiDoc / Markdown.
- Matches conventional English rendering and the style used elsewhere in these repos.
- Behaviour-neutral text change, but one replacement is in an `IllegalArgumentException` message in `SingleThreadedFlatBitSetFrame`.

## Test plan
- [ ] Visual diff - only abbreviation spacing changes.
- [ ] Runtime-visible string changes are limited to punctuation/spacing.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)