### PR TITLE
docs: replace retired maven-badges.herokuapp.com and dead search.maven.org URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Chronicle-Algorithms
 
-<a href="https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-algorithms">
-<img src="https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-algorithms/badge.svg"/>
+<a href="https://central.sonatype.com/artifact/net.openhft/chronicle-algorithms">
+<img src="https://img.shields.io/maven-central/v/net.openhft/chronicle-algorithms.svg"/>
 </a>
 <a href="https://javadoc.io/doc/net.openhft/chronicle-algorithms">
 <img src="https://javadoc.io/badge2/net.openhft/chronicle-algorithms/javadoc.svg"/>


### PR DESCRIPTION
## Summary
- **Heroku retired free tier** so `maven-badges.herokuapp.com` is unreliable. Badges now point at `img.shields.io/maven-central/v/<group>/<artifact>.svg`.
- Badge/artifact links point at `central.sonatype.com/artifact/<group>/<artifact>` (the canonical Maven Central artifact page).
- Dead/clunky `search.maven.org/#search?g=...&a=...` URLs collapse to the same `central.sonatype.com/artifact/<g>/<a>` page.

## Test plan
- [ ] Click the Maven Central badge - should load a version.
- [ ] Click the artifact link - should land on Sonatype Central.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)