### PR TITLE
docs: fix produce -> produces conjugation in hash javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/algo/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/LongHashFunction.java
@@ -34,7 +34,7 @@ import static net.openhft.chronicle.algo.bytes.Accessor.*;
  *     is defined by the given {@link ReadAccess} strategy to the given object.</li>
  * </ul>
  *
- * <p>Hash function implementation could either produce equal results for equal input on platforms
+ * <p>Hash function implementation either produces equal results for equal input on platforms
  * with different {@link ByteOrder}, favoring one byte order in terms of performance, or different
  * results, but performing equally good. This choice should be explicitly documented for all
  * {@code LongHashFunction} implementations.
@@ -67,7 +67,7 @@ public abstract class LongHashFunction implements Serializable {
     /**
      * Returns a hash function implementing
      * <a href="https://code.google.com/p/cityhash/source/browse/trunk/src/city.cc?r=10">
-     * CityHash64 algorithm, version 1.1</a> without seed values. This implementation produce
+     * CityHash64 algorithm, version 1.1</a> without seed values. This implementation produces
      * equal results for equal input on platforms with different {@link ByteOrder}, but is slower
      * on big-endian platforms than on little-endian.
      *
@@ -81,7 +81,7 @@ public abstract class LongHashFunction implements Serializable {
     /**
      * Returns a hash function implementing
      * <a href="https://code.google.com/p/cityhash/source/browse/trunk/src/city.cc?r=10">
-     * CityHash64 algorithm, version 1.1</a> using the given seed value. This implementation produce
+     * CityHash64 algorithm, version 1.1</a> using the given seed value. This implementation produces
      * equal results for equal input on platforms with different {@link ByteOrder}, but is slower
      * on big-endian platforms than on little-endian.
      *
@@ -110,7 +110,7 @@ public abstract class LongHashFunction implements Serializable {
      * Returns a hash function implementing
      * <a href="https://github.com/Cyan4973/xxHash/releases/tag/r39">xxHash
      * algorithm, release 39</a> without seed value (0 is used as default seed value).
-     * This implementation produce equal results for equal
+     * This implementation produces equal results for equal
      * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms
      * than on little-endian.
      *
@@ -126,7 +126,7 @@ public abstract class LongHashFunction implements Serializable {
      * Returns a hash function implementing
      * <a href="https://github.com/Cyan4973/xxHash/releases/tag/r39">xxHash
      * algorithm, release 39</a> with the given seed value.
-     * This implementation produce equal results for equal
+     * This implementation produces equal results for equal
      * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms
      * than on little-endian.
      *
@@ -141,7 +141,7 @@ public abstract class LongHashFunction implements Serializable {
     /**
      * Returns a hash function implementing
      * <a href="https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp">MurmurHash3
-     * algorithm</a> without seed values. This implementation produce equal results for equal input
+     * algorithm</a> without seed values. This implementation produces equal results for equal input
      * on platforms with different {@link ByteOrder}, but is slower on big-endian platforms than on
      * little-endian.
      *
@@ -154,7 +154,7 @@ public abstract class LongHashFunction implements Serializable {
     /**
      * Returns a hash function implementing
      * <a href="https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp">MurmurHash3
-     * algorithm</a> with the given seed value. This implementation produce equal results for equal
+     * algorithm</a> with the given seed value. This implementation produces equal results for equal
      * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms
      * than on little-endian.
      *
@@ -193,7 +193,7 @@ public abstract class LongHashFunction implements Serializable {
      * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
      * the result of {@code hashShort(v)} call is identical to the result of
      * {@code hashShorts(new short[] {v})} call for any {@code short} value.
-     * As a consequence, {@code hashShort(v)} call produce always the same result as {@code
+     * As a consequence, {@code hashShort(v)} call produces always the same result as {@code
      * hashChar((char) v)}.
      */
     public abstract long hashShort(short input);
@@ -204,7 +204,7 @@ public abstract class LongHashFunction implements Serializable {
      * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
      * the result of {@code hashChar(v)} call is identical to the result of
      * {@code hashChars(new char[] {v})} call for any {@code char} value.
-     * As a consequence, {@code hashChar(v)} call produce always the same result as {@code
+     * As a consequence, {@code hashChar(v)} call produces always the same result as {@code
      * hashShort((short) v)}.
      */
     public abstract long hashChar(char input);


### PR DESCRIPTION
## Summary
- "This implementation produce equal results" -> "produces".
- "call produce always the same result" -> "call produces always...".
- "could either produce equal results" -> "either produces equal results".

Javadoc only - no runtime changes.

## Test plan
- [ ] CI green (doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)