### PR TITLE
docs: fix common typos

### DIFF
--- a/src/main/java/net/openhft/chronicle/algo/hashing/XxHash_r39.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/XxHash_r39.java
@@ -11,7 +11,7 @@ import static net.openhft.chronicle.algo.hashing.LongHashFunction.NATIVE_LITTLE_
 /**
  * Adapted version of xxHash implementation from
  * https://github.com/Cyan4973/xxHash/releases/tag/r39, which is fully compatible with r40 though.
- * This implementation provides endian-independant hash values,
+ * This implementation provides endian-independent hash values,
  * but it's slower on big-endian platforms.
  */
 class XxHash_r39 {


### PR DESCRIPTION
## Summary
Typo fixes covering: `locaiton`, `receieved`, `visibe`, `receipient`, `Signtaure`, `signatire`, `extenstions`, `diabled`, `overriden`, `sl4j`, `andd`, `resuable`, `endian-independant`, `benchamrk`, `by used`/`will replaced`, and the `CPI` -> `CPU` slip in AffinityLock javadoc.

Doc-only - no behaviour changes.

## Test plan
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)