### PR TITLE
docs: convert narrative US spellings to UK English

### DIFF
--- a/src/main/java/net/openhft/chronicle/algo/MemoryUnit.java
+++ b/src/main/java/net/openhft/chronicle/algo/MemoryUnit.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
  * A {@code MemoryUnit} represents memory amounts at a given unit of
  * granularity and provides utility methods to convert across units.  A
  * {@code MemoryUnit} does not maintain memory information, but only
- * helps organize and use memory amounts representations that may be maintained
+ * helps organise and use memory amounts representations that may be maintained
  * separately across various contexts.
  *
  * <p>Note than in this class kilo-, mega- and giga- prefixes means 2^10 = 1024 multiplexing,

--- a/src/main/java/net/openhft/chronicle/algo/hashing/CityHash_1_1.java
+++ b/src/main/java/net/openhft/chronicle/algo/hashing/CityHash_1_1.java
@@ -423,7 +423,7 @@ class CityHash_1_1 {
         public static final AsLongHashFunction INSTANCE = new AsLongHashFunction();
         private static final long serialVersionUID = 0L;
         private static final int FIRST_SHORT_BYTE_SHIFT = NATIVE_LITTLE_ENDIAN ? 0 : 8;
-        // JIT could probably optimize & -1 to no-op
+        // JIT could probably optimise & -1 to no-op
         private static final int FIRST_SHORT_BYTE_MASK = NATIVE_LITTLE_ENDIAN ? 0xFF : -1;
         private static final int SECOND_SHORT_BYTE_SHIFT = 8 - FIRST_SHORT_BYTE_SHIFT;
         private static final int SECOND_SHORT_BYTE_MASK = NATIVE_LITTLE_ENDIAN ? -1 : 0xFF;

--- a/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockState.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockState.java
@@ -5,7 +5,7 @@ package net.openhft.chronicle.algo.locks;
 
 /**
  * Abstract base class for managing read-write lock state.
- * Implements common behavior for acquiring and releasing write locks.
+ * Implements common behaviour for acquiring and releasing write locks.
  */
 public abstract class AbstractReadWriteLockState implements ReadWriteLockState {
 

--- a/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockingStrategy.java
+++ b/src/main/java/net/openhft/chronicle/algo/locks/AbstractReadWriteLockingStrategy.java
@@ -7,7 +7,7 @@ import net.openhft.chronicle.algo.bytes.Access;
 
 /**
  * Abstract base class for read-write locking strategies.
- * Implements common behavior for acquiring and releasing write locks.
+ * Implements common behaviour for acquiring and releasing write locks.
  */
 public abstract class AbstractReadWriteLockingStrategy implements ReadWriteLockingStrategy {
 

--- a/src/test/java/net/openhft/chronicle/algo/bytes/WriteAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/algo/bytes/WriteAccessTest.java
@@ -25,7 +25,7 @@ class WriteAccessTest {
         writeAccess = Mockito.spy(WriteAccess.class);
         handle = new byte[16];
 
-        // Mock behavior for writeByte
+        // Mock behaviour for writeByte
         doAnswer(invocation -> {
             byte[] h = invocation.getArgument(0);
             long offset = invocation.getArgument(1);
@@ -34,7 +34,7 @@ class WriteAccessTest {
             return null;
         }).when(writeAccess).writeByte(any(byte[].class), anyLong(), anyByte());
 
-        // Mock behavior for writeShort
+        // Mock behaviour for writeShort
         doAnswer(invocation -> {
             byte[] h = invocation.getArgument(0);
             long offset = invocation.getArgument(1);
@@ -44,7 +44,7 @@ class WriteAccessTest {
             return null;
         }).when(writeAccess).writeShort(any(byte[].class), anyLong(), anyShort());
 
-        // Mock behavior for writeInt
+        // Mock behaviour for writeInt
         doAnswer(invocation -> {
             byte[] h = invocation.getArgument(0);
             long offset = invocation.getArgument(1);
@@ -56,7 +56,7 @@ class WriteAccessTest {
             return null;
         }).when(writeAccess).writeInt(any(byte[].class), anyLong(), anyInt());
 
-        // Mock behavior for writeLong
+        // Mock behaviour for writeLong
         doAnswer(invocation -> {
             byte[] h = invocation.getArgument(0);
             long offset = invocation.getArgument(1);
@@ -72,7 +72,7 @@ class WriteAccessTest {
             return null;
         }).when(writeAccess).writeLong(any(byte[].class), anyLong(), anyLong());
 
-        // Mock behavior for writeFloat
+        // Mock behaviour for writeFloat
         doAnswer(invocation -> {
             byte[] h = invocation.getArgument(0);
             long offset = invocation.getArgument(1);
@@ -85,7 +85,7 @@ class WriteAccessTest {
             return null;
         }).when(writeAccess).writeFloat(any(byte[].class), anyLong(), anyFloat());
 
-        // Mock behavior for writeDouble
+        // Mock behaviour for writeDouble
         doAnswer(invocation -> {
             byte[] h = invocation.getArgument(0);
             long offset = invocation.getArgument(1);


### PR DESCRIPTION
## Summary
Documentation uses UK English for narrative text. Standard US technical terms (`synchronization`, `serialization`, `initialization`, `finalize`, `deserialize`, `normalization`) are preserved because that is how they appear in the Java platform and wider ecosystem.

Changes:
- `-or` -> `-our`: behavior, color, favor, flavor, honor, labor, neighbor, endeavor
- `-ize` -> `-ise` for non-technical verbs: organize, recognize, realize, optimize, minimize, maximize, emphasize, utilize, summarize, customize, prioritize, generalize, analyze

Proper nouns (e.g. "Apache License") and third-party paths (e.g. `jsr166/`) are left alone.

## Test plan
- [ ] Diff shows only narrative/spelling swaps.
- [ ] No API or identifier names affected.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)